### PR TITLE
Improve the `Index` structure

### DIFF
--- a/sitemap.go
+++ b/sitemap.go
@@ -10,12 +10,12 @@ import (
 
 // Index is a structure of <sitemapindex>
 type Index struct {
-	XMLName xml.Name `xml:"sitemapindex"`
-	Sitemap []parts  `xml:"sitemap"`
+	XMLName xml.Name    `xml:"sitemapindex"`
+	Sitemap []indexPart `xml:"sitemap"`
 }
 
-// parts is a structure of <sitemap> in <sitemapindex>
-type parts struct {
+// indexPart is a structure of <sitemap> in <sitemapindex>
+type indexPart struct {
 	Loc     string `xml:"loc"`
 	LastMod string `xml:"lastmod"`
 }

--- a/sitemap.go
+++ b/sitemap.go
@@ -11,11 +11,11 @@ import (
 // Index is a structure of <sitemapindex>
 type Index struct {
 	XMLName xml.Name    `xml:"sitemapindex"`
-	Sitemap []indexPart `xml:"sitemap"`
+	Sitemap []IndexPart `xml:"sitemap"`
 }
 
-// indexPart is a structure of <sitemap> in <sitemapindex>
-type indexPart struct {
+// IndexPart is a structure of <sitemap> in <sitemapindex>
+type IndexPart struct {
 	Loc     string `xml:"loc"`
 	LastMod string `xml:"lastmod"`
 }


### PR DESCRIPTION
I made the type of the field `Sitemap` public. This change has the following benefits:

- **Comfortable unit testing:** now I can make an expected instance of the `Index` structure not through parsing, but by direct constructing.
- **Support for constructing specific instances:** now I can manually add multiple links to a Sitemap index or even make an entire instance for specific cases (such as a default value).

If this field is private, the above will not be possible, at least not in a simple way.

Yes, I found the commit a4c59c17a59a064b878fdbe746dd9538975907b2 where you, on the contrary, made this field private, but there is no explanation.

---

About name selection:

- I used a singular form because this structure represents a single instance of some entity.
- I added the prefix `Index` because the word `part` is too general.
